### PR TITLE
feat(labeler): :fire: remove default message if XL

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -23,7 +23,5 @@ jobs:
           l_label: 'size/L'
           l_max_size: '500'
           xl_label: 'size/XL'
-          xl_max_size: '1000'
-          xxl_label: 'size/XXL'
-          fail_if_xxl: 'false'
+          message_if_xl: ''
           files_to_ignore: 'package-lock.json *.lock'


### PR DESCRIPTION
+ Given the source code, message_if_xl is not required but has default value so we get spammed after each push.
+ Remove XXL logic, does not exists with this lib