### PR TITLE
fix(e2e-tests): 🐛 Add required ref parameter to body.

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -3,21 +3,17 @@ name: Execute E2E tests
 on:
   workflow_call:
     inputs:
-      target_api:
-        type: string
-        description: Target API for the e2e tests
-        required: true
       sleep:
         type: boolean
         description: Sleep for 5 minutes
         default: false
-      url:
-        type: string
-        description: The url to test
-        required: false
       application:
         type: string
         description: The application to test
+        required: false
+      url:
+        type: string
+        description: The url to test
         required: false
     secrets:
       e2e_access_token:
@@ -32,7 +28,7 @@ jobs:
       - name: Dispatches end to end test
         shell: bash
         run: |
-          curl -X POST ${{ inputs.target_api }} \
+          curl -X POST https://api.github.com/repos/vaultinum/vaultinum-e2e/actions/workflows/tests.yml/dispatches \
           -H 'Accept: application/vnd.github.everest-preview+json' \
           -H 'Authorization: token ${{ secrets.e2e_access_token }}' \
-          --data '{ "ref":"${{ github.ref_name }}", "inputs":{ "sleep": "${{ inputs.sleep }}", "application": "${{ inputs.application }}", "url": "${{ inputs.url }}" }}'
+          --data '{ "ref": "main", "inputs":{ "sleep": "${{ inputs.sleep }}", "application": "${{ inputs.application }}", "url": "${{ inputs.url }}" }}'

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -35,4 +35,4 @@ jobs:
           curl -X POST ${{ inputs.target_api }} \
           -H 'Accept: application/vnd.github.everest-preview+json' \
           -H 'Authorization: token ${{ secrets.e2e_access_token }}' \
-          --data '{"inputs":{ "sleep": "${{ inputs.sleep }}", "application": "${{ inputs.application }}", "url": "${{ inputs.url }}" }}'
+          --data '{ "ref":"${{ github.ref_name }}", "inputs":{ "sleep": "${{ inputs.sleep }}", "application": "${{ inputs.application }}", "url": "${{ inputs.url }}" }}'

--- a/.github/workflows/staging-deployment.yaml
+++ b/.github/workflows/staging-deployment.yaml
@@ -10,10 +10,6 @@ on:
         type: boolean
         description: Sleep for 5 minutes
         default: false
-      target_api:
-        type: string
-        description: Target API for the e2e tests
-        required: false
       url:
         type: string
         description: The url to test
@@ -90,9 +86,8 @@ jobs:
     if: ${{ inputs.run_tests == 'true' }}
     uses: ./.github/workflows/e2e-tests.yaml
     with:
-      target_api: ${{ inputs.target_api }}
       sleep: ${{ inputs.sleep }}
-      url: ${{ inputs.url }}
       application: ${{ inputs.application }}
+      url: ${{ inputs.url }}
     secrets:
       e2e_access_token: ${{ secrets.E2E_ACCESS_TOKEN }}


### PR DESCRIPTION
```
{
  "message": "Invalid request.\n\n\"ref\" wasn't supplied.",
  "documentation_url": "https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event"
}
```
[ref string Obligatoire](https://docs.github.com/fr/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
The git reference for the workflow. The reference can be a branch or tag name.