### PR TITLE
feat(PROOF-706): open deploy PR workflow

### DIFF
--- a/.github/workflows/open-deployment-pr.yaml
+++ b/.github/workflows/open-deployment-pr.yaml
@@ -1,0 +1,45 @@
+name: Deployment auto PR
+
+on:
+  workflow_call:
+    inputs:
+      target_branch:
+        required: true
+        type: string
+      pr_title:
+        required: true
+        type: string
+      pr_body:
+        required: true
+        type: string
+      run_tests:
+        default: false
+        type: boolean
+    secrets:
+      GH_TOKEN:
+        required: true
+      SONAR_TOKEN:
+        required: true
+      SONAR_URL:
+        required: true
+
+jobs:
+  open-deployment-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create PR with GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh auth setup-git
+          gh pr create \
+            --base ${{ inputs.target_branch }} \
+            --head ${{ github.ref_name }} \
+            --title "${{ inputs.pr_title }}" \
+            --body "${{ inputs.pr_body }}" \
+            --label "deploy" \
+            --draft
+  sonarqube:
+    uses: ./.github/workflows/sonarqube.yaml
+    secrets: inherit

--- a/.github/workflows/open-staging-pr.yaml
+++ b/.github/workflows/open-staging-pr.yaml
@@ -1,3 +1,10 @@
+# ================================================================
+# DEPRECATED WORKFLOW
+# This workflow is deprecated for two reasons:
+# 1. the workflow `repo-sync/pull-request@v2` is deprecated
+# 2. does not offer the flexibility to choose another target branch
+# Please use 'open-deployment-pr.yaml' instead.
+# ================================================================
 name: Staging auto PR
 
 on:


### PR DESCRIPTION
An alternative to open-staging-pr:
- allows as input the target branch to create the PR on
- uses github cli which is now the recommended way to open PRs automatically